### PR TITLE
Refactor release workflow to use pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+name: Publish
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'release: v')
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Check for dry-run
+        id: dry-run
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$PR_LABELS" | grep -q "release:dry-run"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.dry-run.outputs.skip != 'true'
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract changelog entry for this version
+          BODY=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          if [ -z "$BODY" ]; then
+            BODY="Release v${VERSION}"
+          fi
+
+          EXTRA=""
+          if [ "${{ steps.dry-run.outputs.skip }}" = "true" ]; then
+            EXTRA="
+
+          > **Note**: This was a dry-run release. The package was NOT published to npm."
+          fi
+
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes "${BODY}${EXTRA}" \
+            --target main
+
+      - name: Delete release branch
+        continue-on-error: true
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          git push origin --delete "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -105,46 +105,36 @@ jobs:
             echo "[${NEW_VERSION}]: ${REPO_URL}/compare/v${OLD_VERSION}...v${NEW_VERSION}" >> CHANGELOG.md
           fi
 
-      - name: Commit and tag
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.new_version }}"
-          git add package.json CHANGELOG.md
-          git commit -m "release: v${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-
-      - name: Push changes
-        run: |
-          git push origin main
-          git push origin "v${{ steps.version.outputs.new_version }}"
-
-      - name: Publish to npm
-        if: ${{ !inputs.dry-run }}
-        run: pnpm publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
+      - name: Create release branch and PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
           OLD_VERSION="${{ steps.version.outputs.old_version }}"
+          BRANCH="release/v${NEW_VERSION}"
 
-          # Extract changelog entry for this version
-          BODY=$(awk "/^## \[${NEW_VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+          git checkout -b "$BRANCH"
+          git add package.json CHANGELOG.md
+          git commit -m "release: v${NEW_VERSION}"
+          git push origin "$BRANCH"
 
-          if [ -z "$BODY" ]; then
-            BODY="Release v${NEW_VERSION}"
-          fi
-
-          EXTRA=""
+          DRY_RUN_LABEL=""
           if [ "${{ inputs.dry-run }}" = "true" ]; then
-            EXTRA="
-
-          > **Note**: This was a dry-run release. The package was NOT published to npm."
+            DRY_RUN_LABEL="--label release:dry-run"
           fi
 
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --notes "${BODY}${EXTRA}" \
-            --target main
+          gh pr create \
+            --title "release: v${NEW_VERSION}" \
+            --body "## Release v${NEW_VERSION}
+
+          Automated release PR.
+
+          **Version**: ${OLD_VERSION} → ${NEW_VERSION}
+
+          Once this PR is merged, the publish workflow will automatically:
+          - Create the \`v${NEW_VERSION}\` tag
+          - Publish to npm
+          - Create a GitHub Release" \
+            --base main \
+            --head "$BRANCH" \
+            --label release $DRY_RUN_LABEL


### PR DESCRIPTION
## Summary
This change refactors the release process to use a two-step workflow: the existing `release.yml` workflow now creates a pull request instead of directly publishing, and a new `publish.yml` workflow handles the actual publishing when the PR is merged.

## Key Changes

- **New `publish.yml` workflow**: Automatically triggered when a release PR is merged, handles:
  - Creating and pushing version tags
  - Publishing to npm (unless marked as dry-run)
  - Creating GitHub releases with changelog entries
  - Cleaning up the release branch

- **Modified `release.yml` workflow**: Now creates a release PR instead of directly publishing:
  - Generates version bump and updates CHANGELOG.md
  - Creates a feature branch and opens a PR with release details
  - Supports dry-run releases via PR labels
  - Removed direct npm publishing and GitHub release creation
  - Removed `environment: production` requirement

- **Added `pull-requests: write` permission** to `release.yml` to enable PR creation

## Benefits

- **Better review process**: Release changes can be reviewed before publishing
- **Clearer audit trail**: Each release is documented as a merged PR
- **Safer dry-runs**: Dry-run releases are clearly marked and don't publish to npm
- **Separation of concerns**: Version bumping and publishing are now separate workflows
- **Easier rollback**: Release branches can be deleted without affecting main branch history

https://claude.ai/code/session_01Tpu3j4oFnTKEghhtpxXoND