### PR TITLE
Clean up existing release branches before creating new ones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,18 @@ jobs:
           OLD_VERSION="${{ steps.version.outputs.old_version }}"
           BRANCH="release/v${NEW_VERSION}"
 
+          # Clean up existing release branch/PR from previous attempts
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" > /dev/null 2>&1; then
+            echo "Remote branch $BRANCH already exists. Cleaning up..."
+            EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "Closing existing PR #${EXISTING_PR}..."
+              gh pr close "$EXISTING_PR" --delete-branch
+            else
+              git push origin --delete "$BRANCH"
+            fi
+          fi
+
           git checkout -b "$BRANCH"
           git add package.json CHANGELOG.md
           git commit -m "release: v${NEW_VERSION}"


### PR DESCRIPTION
## Summary
This change adds cleanup logic to the release workflow to handle cases where a release branch or pull request already exists from a previous failed or incomplete release attempt.

## Key Changes
- Added pre-flight check to detect if a release branch already exists on the remote
- If an open PR exists for the branch, close it and delete the branch
- If only the branch exists (no PR), delete it directly
- This prevents conflicts and allows the release workflow to proceed cleanly on retry

## Implementation Details
The cleanup logic:
1. Uses `git ls-remote` to check if the release branch exists on origin
2. Queries for any open PRs associated with that branch using `gh pr list`
3. Closes the PR with `--delete-branch` flag if found (which also deletes the branch)
4. Falls back to direct branch deletion via `git push origin --delete` if no PR exists
5. Executes before attempting to create the new release branch

This ensures idempotent behavior when the release workflow is re-run after a failure.

https://claude.ai/code/session_01TBUZtJ9aSuTutqGioB8ksm